### PR TITLE
Fix a bug where some captures weren't working

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -217,7 +217,7 @@ mod tests {
         errors::{ChessPositionError, MoveError, PgnError},
         utils::{Color, Position},
     };
-
+    use crate::io::ui::print_game;
     use super::GameState;
 
     #[test]
@@ -257,6 +257,8 @@ mod tests {
             Position::new(2, 5),
         )?;
 
+        print_game(&game_state);
+        
         assert_eq!(game_state.turn, Color::White);
         make_and_validate_move(
             &mut game_state,
@@ -264,6 +266,8 @@ mod tests {
             Position::new(3, 1),
             Position::new(1, 3),
         )?;
+        
+        print_game(&game_state);
 
         assert_eq!(game_state.turn, Color::Black);
         make_and_validate_move(

--- a/src/pieces/bishop.rs
+++ b/src/pieces/bishop.rs
@@ -48,6 +48,7 @@ pub fn can_move(board: &Board, origin: Position, destination: Position) -> bool 
 
     let mut i = (src_line + vertical_direction) as usize;
     let mut j = (src_col + horizontal_direction) as usize;
+    // TODO rever esse "-1" abaixo, pois talvez só faça sentido em caso de captura (ataque)
     let nr_of_squares = (dest_col - src_col).abs() - 1;
     for _ in 0..nr_of_squares {
         if board[i][j].is_some() {

--- a/src/pieces/bishop.rs
+++ b/src/pieces/bishop.rs
@@ -1,40 +1,41 @@
-use crate::utils::Position;
 use crate::utils::types::Board;
+use crate::utils::Position;
 
 pub const SYMBOLS: [char; 2] = ['\u{2657}', '\u{265D}'];
-
-// pub fn get_possible_moves(board: &Board, origin: Position) -> PossibleMoves {
-//     let mut up = 0..origin.line;
-//     let mut down = (origin.line + 1)..BOARD_SIZE;
-//     let mut left = 0..origin.col;
-//     let mut right = (origin.col + 1)..BOARD_SIZE;
-// 
-//     let mut possible_moves: PossibleMoves = Default::default();
-// 
-//     check_diagonal(board, &mut up, &mut right, &mut possible_moves);
-// 
-//     check_diagonal(board, &mut up, &mut left, &mut possible_moves);
-// 
-//     check_diagonal(board, &mut down, &mut right, &mut possible_moves);
-// 
-//     check_diagonal(board, &mut down, &mut left, &mut possible_moves);
-// 
-//     possible_moves
-// }
-// 
-// fn check_diagonal(board: &Board, vertical_range: &mut Range<usize>, horizontal_range: &mut Range<usize>, possible_moves: &mut PossibleMoves) {
-//     for (i, j) in vertical_range.by_ref().zip(horizontal_range.by_ref()) {
-//         if board[i][j].is_some() {
-//             break;
-//         }
-//         possible_moves[i][j] = true;
-//     }
-// }
 
 pub fn can_move(board: &Board, origin: Position, destination: Position) -> bool {
     let (src_line, src_col) = (origin.line as i8, origin.col as i8);
     let (dest_line, dest_col) = (destination.line as i8, destination.col as i8);
 
+    if !is_move_valid(src_line, src_col, dest_line, dest_col) {
+        return false;
+    }
+
+    let nr_of_squares = (dest_col - src_col).abs();
+    if !is_path_clear(board, src_line, src_col, dest_line, dest_col, nr_of_squares) {
+        return false;
+    }
+
+    return true;
+}
+
+pub fn attacks(board: &Board, origin: Position, destination: Position) -> bool {
+    let (src_line, src_col) = (origin.line as i8, origin.col as i8);
+    let (dest_line, dest_col) = (destination.line as i8, destination.col as i8);
+
+    if !is_move_valid(src_line, src_col, dest_line, dest_col) {
+        return false;
+    }
+
+    let nr_of_squares = (dest_col - src_col).abs() - 1;
+    if !is_path_clear(board, src_line, src_col, dest_line, dest_col, nr_of_squares) {
+        return false;
+    }
+
+    return true;
+}
+
+fn is_move_valid(src_line: i8, src_col: i8, dest_line: i8, dest_col: i8) -> bool {
     if (src_line == dest_line) || (src_col == dest_col) {
         return false;
     }
@@ -43,13 +44,22 @@ pub fn can_move(board: &Board, origin: Position, destination: Position) -> bool 
         return false;
     }
 
+    return true;
+}
+
+fn is_path_clear(
+    board: &Board,
+    src_line: i8,
+    src_col: i8,
+    dest_line: i8,
+    dest_col: i8,
+    nr_of_squares: i8,
+) -> bool {
     let horizontal_direction = (dest_col - src_col) / (dest_col - src_col).abs();
     let vertical_direction = (dest_line - src_line) / (dest_line - src_line).abs();
 
     let mut i = (src_line + vertical_direction) as usize;
     let mut j = (src_col + horizontal_direction) as usize;
-    // TODO rever esse "-1" abaixo, pois talvez só faça sentido em caso de captura (ataque)
-    let nr_of_squares = (dest_col - src_col).abs() - 1;
     for _ in 0..nr_of_squares {
         if board[i][j].is_some() {
             return false;
@@ -60,8 +70,4 @@ pub fn can_move(board: &Board, origin: Position, destination: Position) -> bool 
     }
 
     return true;
-}
-
-pub fn attacks(board: &Board, origin: Position, destination: Position) -> bool {
-    can_move(board, origin, destination)
 }

--- a/src/pieces/king.rs
+++ b/src/pieces/king.rs
@@ -7,6 +7,7 @@ pub fn can_move(origin: Position, destination: Position) -> bool {
     let (src_line, src_col) = (origin.line as i8, origin.col as i8);
     let (dest_line, dest_col) = (destination.line as i8, destination.col as i8);
 
+    // TODO this can be improved...
     for i in -1..2_i8 {
         for j in -1..2_i8 {
             if i == 0 && j == 0 {

--- a/src/pieces/pawn.rs
+++ b/src/pieces/pawn.rs
@@ -1,11 +1,11 @@
-use crate::utils::{Color, Position};
 use crate::utils::types::Board;
+use crate::utils::{Color, Position};
 
 use super::Piece;
 
 pub const SYMBOLS: [char; 2] = ['\u{2659}', '\u{265F}'];
 
-pub fn can_move(board: &Board, piece: &Piece, origin: Position, destination: Position, capture: bool) -> bool {
+pub fn can_move(board: &Board, piece: &Piece, origin: Position, destination: Position) -> bool {
     let (src_line, src_col) = (origin.line as i8, origin.col as i8);
     let (dest_line, dest_col) = (destination.line as i8, destination.col as i8);
 
@@ -26,17 +26,15 @@ pub fn can_move(board: &Board, piece: &Piece, origin: Position, destination: Pos
             vertical_distance = dest_line - src_line;
         }
     }
-    let horizontal_distance = (src_col - dest_col).abs();
-
-    if capture {
-        return vertical_distance == 1 && horizontal_distance == 1;
-    }
 
     if dest_col != src_col {
         return false;
     }
 
-    return vertical_distance == 1 || (allow_two_rows && vertical_distance == 2 && check_clear_path(board, origin, destination));
+    return vertical_distance == 1
+        || (allow_two_rows
+            && vertical_distance == 2
+            && check_clear_path(board, origin, destination));
 }
 
 fn check_clear_path(board: &Board, origin: Position, destination: Position) -> bool {
@@ -53,7 +51,7 @@ pub fn attacks(piece_color: Color, origin: Position, destination: Position) -> b
     let abs_horizontal_distance = (dest_col - src_col).abs();
 
     match piece_color {
-        Color::White => vertical_distance == 1 && abs_horizontal_distance == 1,
-        Color::Black => vertical_distance == -1 && abs_horizontal_distance == 1,
+        Color::White => vertical_distance == -1 && abs_horizontal_distance == 1,
+        Color::Black => vertical_distance == 1 && abs_horizontal_distance == 1,
     }
 }

--- a/src/pieces/piece.rs
+++ b/src/pieces/piece.rs
@@ -36,7 +36,6 @@ pub struct Piece {
     symbol: char,
     pub piece_type: PieceType,
     pub color: Color,
-    // possible_moves: PossibleMoves,
 }
 
 impl Piece {
@@ -45,58 +44,45 @@ impl Piece {
             symbol: Self::get_symbol(&piece_type, &color),
             piece_type,
             color,
-            // possible_moves: Default::default(),
         }
     }
 
-    // pub fn update_possible_moves(
-    //     &mut self,
-    //     board: &Board,
-    //     origin: Position,
-    // ) {
-    //     match self.piece_type {
-    //         PieceType::Bishop => self.possible_moves = bishop::get_possible_moves(board, origin),
-    //         PieceType::King => self.possible_moves = king::get_possible_moves(board, origin),
-    //         PieceType::Knight => self.possible_moves = knight::get_possible_moves(board, origin),
-    //         PieceType::Pawn => self.possible_moves = pawn::get_possible_moves(board, origin),
-    //         PieceType::Queen => self.possible_moves = queen::get_possible_moves(board, origin),
-    //         PieceType::Rook => self.possible_moves = rook::get_possible_moves(board, origin),
-    //     }
-    // }
-    //
     pub fn can_move(
+        &self,
+        board: &Board,
+        origin: Position,
+        destination: Position,
+    ) -> Result<bool, MoveError> {
+        self.validate_capture(&board[destination.line][destination.col], false)?;
+
+        match self.piece_type {
+            PieceType::Bishop => Ok(bishop::can_move(board, origin, destination)),
+            PieceType::King => Ok(king::can_move(origin, destination)),
+            PieceType::Knight => Ok(knight::can_move(origin, destination)),
+            PieceType::Pawn => Ok(pawn::can_move(board, self, origin, destination)),
+            PieceType::Queen => Ok(queen::can_move(board, origin, destination)),
+            PieceType::Rook => Ok(rook::can_move(board, origin, destination)),
+        }
+    }
+
+    pub fn attacks(
         &self,
         board: &Board,
         origin: Position,
         destination: Position,
         capture: bool,
     ) -> Result<bool, MoveError> {
-        self.validate_capture(&board[destination.line][destination.col], capture)?;
-
-        match self.piece_type {
-            PieceType::Bishop => Ok(bishop::can_move(board, origin, destination)),
-            PieceType::King => Ok(king::can_move(origin, destination)),
-            PieceType::Knight => Ok(knight::can_move(origin, destination)),
-            PieceType::Pawn => Ok(pawn::can_move(board, self, origin, destination, capture)),
-            PieceType::Queen => Ok(queen::can_move(board, origin, destination)),
-            PieceType::Rook => Ok(rook::can_move(board, origin, destination)),
+        if capture {
+            self.validate_capture(&board[destination.line][destination.col], true)?;
         }
-    }
 
-    // TODO rever o uso do método abaixo, se ele for usado sempre em caso de captura, então podemos eliminar o booleano "capture" do método acima e implementar lógicas de captura nas funções "attacks" de cada peça
-    pub fn attacks(
-        &self,
-        board: &Board,
-        origin: Position,
-        destination: Position,
-    ) -> bool {
         match self.piece_type {
-            PieceType::Bishop => bishop::attacks(board, origin, destination),
-            PieceType::King => king::attacks(origin, destination),
-            PieceType::Knight => knight::attacks(origin, destination),
-            PieceType::Pawn => pawn::attacks(self.color, origin, destination),
-            PieceType::Queen => queen::attacks(board, origin, destination),
-            PieceType::Rook => rook::attacks(board, origin, destination),
+            PieceType::Bishop => Ok(bishop::attacks(board, origin, destination)),
+            PieceType::King => Ok(king::attacks(origin, destination)),
+            PieceType::Knight => Ok(knight::attacks(origin, destination)),
+            PieceType::Pawn => Ok(pawn::attacks(self.color, origin, destination)),
+            PieceType::Queen => Ok(queen::attacks(board, origin, destination)),
+            PieceType::Rook => Ok(rook::attacks(board, origin, destination)),
         }
     }
 

--- a/src/pieces/piece.rs
+++ b/src/pieces/piece.rs
@@ -83,6 +83,7 @@ impl Piece {
         }
     }
 
+    // TODO rever o uso do método abaixo, se ele for usado sempre em caso de captura, então podemos eliminar o booleano "capture" do método acima e implementar lógicas de captura nas funções "attacks" de cada peça
     pub fn attacks(
         &self,
         board: &Board,

--- a/src/pieces/queen.rs
+++ b/src/pieces/queen.rs
@@ -10,5 +10,5 @@ pub fn can_move(board: &Board, origin: Position, destination: Position) -> bool 
 }
 
 pub fn attacks(board: &Board, origin: Position, destination: Position) -> bool {
-    can_move(board, origin, destination)
+    bishop::attacks(board, origin, destination) || rook::attacks(board, origin, destination)
 }

--- a/src/pieces/rook.rs
+++ b/src/pieces/rook.rs
@@ -30,6 +30,7 @@ pub fn can_move(board: &Board, origin: Position,  destination: Position) -> bool
 
     let mut i = (src_line + vertical_direction) as usize;
     let mut j = (src_col + horizontal_direction) as usize;
+    // TODO rever a linha abaixo, talvez seja necessário adicionar um "-1" como foi feito no bishop em caso de captura (ataque)
     let nr_of_squares = max((dest_col - src_col).abs(), (dest_line - src_line).abs());
     for _ in 0..nr_of_squares {
         if board[i][j].is_some() {

--- a/src/pieces/rook.rs
+++ b/src/pieces/rook.rs
@@ -30,7 +30,6 @@ pub fn can_move(board: &Board, origin: Position,  destination: Position) -> bool
 
     let mut i = (src_line + vertical_direction) as usize;
     let mut j = (src_col + horizontal_direction) as usize;
-    // TODO rever a linha abaixo, talvez seja necessário adicionar um "-1" como foi feito no bishop em caso de captura (ataque)
     let nr_of_squares = max((dest_col - src_col).abs(), (dest_line - src_line).abs());
     for _ in 0..nr_of_squares {
         if board[i][j].is_some() {
@@ -45,5 +44,40 @@ pub fn can_move(board: &Board, origin: Position,  destination: Position) -> bool
 }
 
 pub fn attacks(board: &Board, origin: Position, destination: Position) -> bool {
-    can_move(board, origin, destination)
+    let (src_line, src_col) = (origin.line as i8, origin.col as i8);
+    let (dest_line, dest_col) = (destination.line as i8, destination.col as i8);
+
+    // Logical XNOR
+    if (src_line == dest_line) == (src_col == dest_col) {
+        return false;
+    }
+
+    // Avoid division by zero
+    let horizontal_direction = if (dest_col - src_col) != 0 {
+        (dest_col - src_col) / (dest_col - src_col).abs()
+    }
+    else {
+        0
+    };
+
+    let vertical_direction = if (dest_line - src_line) != 0 {
+        (dest_line - src_line) / (dest_line - src_line).abs()
+    }
+    else {
+        0
+    };
+
+    let mut i = (src_line + vertical_direction) as usize;
+    let mut j = (src_col + horizontal_direction) as usize;
+    let nr_of_squares = max((dest_col - src_col).abs(), (dest_line - src_line).abs()) - 1;
+    for _ in 0..nr_of_squares {
+        if board[i][j].is_some() {
+            return false;
+        }
+
+        i = (i as i8 + vertical_direction) as usize;
+        j = (j as i8 + horizontal_direction) as usize;
+    }
+
+    return true;
 }


### PR DESCRIPTION
The "can_move" functions were trying to handle both captures and piece movements, but some validations differ between them, causing a behavior where some attempts to capture a piece would throw a "No piece available for this move" error. The fix involved extending the "attacks" functions to also handle captures, beyond "King in check" validations.